### PR TITLE
Make downloader available as a stream

### DIFF
--- a/crates/downloader/Cargo.toml
+++ b/crates/downloader/Cargo.toml
@@ -22,8 +22,10 @@ alloy = { version = "0.4.2", features = [
 fuel-block-committer-encoding = { git = "https://github.com/FuelLabs/fuel-block-committer", branch = "feat/blob_metadata" }
 futures-util = "0.3"
 hex = "0.4.3"
+log = "0.4"
 reqwest = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10.8"
 tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio-stream = "0.1.16"

--- a/crates/downloader/examples/download.rs
+++ b/crates/downloader/examples/download.rs
@@ -1,14 +1,21 @@
 use fuel_network_watchtower_downloader::{Downloader, Config};
+use futures_util::StreamExt;
 
 #[tokio::main]
 async fn main() {
     let config = Config::read_from_env().unwrap();
-    let mut downloader = Downloader::new(config).unwrap();
+    let mut downloader = Downloader::new(config).unwrap().stream();
 
-    let blobs = downloader.next_block_bundles().await.unwrap();
-
-    for (header, bundle) in blobs {
-        println!("Header: {:?}", header);
-        println!("Bundle: {:?}", bundle);
+    while let Some(result) = downloader.next().await {
+        match result {
+            Ok((header, bundle)) => {
+                println!("Header: {:?}", header);
+                println!("Bundle: {:?}", bundle);
+            },
+            Err(e) => {
+                eprintln!("Error: {:?}", e);
+                break;
+            },
+        }
     }
 }


### PR DESCRIPTION
Possible improvement: download blocks in parallel. Currently not done, since it would be more complex and can be done later.